### PR TITLE
Don't change editor's background color

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -13,10 +13,6 @@
   .selection .region { background-color: lighten(@input-background-color, 10%); }
 }
 
-.editor, .editor .gutter {
-  background-color: @app-background-color;
-}
-
 .editor.editor-colors.mini.is-focused {
   .selection .region { background-color: lighten(@app-background-color, 5%); }
   transition: background-color 0.1s


### PR DESCRIPTION
I was using this with Solarized syntax theme and noticed it changing the background of the editor. This, in my opinion, is not how it should be. UI theme should only affect the UI, not the syntax colors.
