### PR TITLE
Updated tree-view.less to include styles for scrollbars.

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -17,3 +17,18 @@
     }
   }
 }
+
+.tree-view-resizer, .editor {
+  ::-webkit-scrollbar {
+    width: 1em;
+    height: 1em;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: #2B303B;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: #232830;
+  }
+}


### PR DESCRIPTION
Updated tree-view.less to include styles for scrollbars.

The theme was initially showing standard scrollbars (white) so I added a few lines of CSS to customize the look.

I used the colours of the theme so that everything blends in.


![screen shot 2014-03-12 at 4 33 01 pm](https://f.cloud.github.com/assets/909749/2393602/0ccf42de-a997-11e3-8aa6-9b4b02a1c65d.png)
