### PR TITLE
fix deprecated selectors

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -4,6 +4,6 @@
 	box-sizing: border-box;
 }
 
-.workspace {
+.atom-workspace {
   background-color: @app-background-color;
 }

--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-.editor.mini {
+atom-text-editor[mini] {
   color: @text-color-highlight;
   background-color: @input-background-color;
   border-radius: @component-border-radius;
@@ -13,7 +13,7 @@
   .selection .region { background-color: lighten(@input-background-color, 10%); }
 }
 
-.editor.editor-colors.mini.is-focused {
+atom-text-editor[mini].is-focused {
   .selection .region { background-color: lighten(@app-background-color, 5%); }
   transition: background-color 0.1s
 }
@@ -23,7 +23,7 @@
   to { background-color: null; }
 }
 
-.editor .highlighted.selection .region {
+atom-text-editor::shadow .highlighted.selection .region {
   -webkit-animation-name: highlight;
   -webkit-animation-duration: 1s;
   -webkit-animation-iteration-count: 1;

--- a/stylesheets/lists.less
+++ b/stylesheets/lists.less
@@ -91,7 +91,7 @@
   border-radius: @component-border-radius;
   border: 1px solid @overlay-border-color;
 
-  .editor {
+  atom-text-editor {
     margin-bottom: @component-padding/2;
   }
 

--- a/stylesheets/overlays.less
+++ b/stylesheets/overlays.less
@@ -1,12 +1,12 @@
 @import "ui-variables";
 
-.overlay {
+atom-panel.modal {
   color: @text-color;
   background-color: @overlay-background-color;
   padding: @component-padding;
   border-radius: @component-border-radius;
 
-  .editor.mini {
+  atom-text-editor[mini] {
     margin-bottom: @component-padding;
   }
 

--- a/stylesheets/panes.less
+++ b/stylesheets/panes.less
@@ -8,8 +8,8 @@
   }
 }
 
-.panes {
-  .pane {
+atom-pane-container {
+  atom-pane {
     background-color: lighten(@app-background-color, 4%);
 
     &:focus {
@@ -17,12 +17,12 @@
     }
   }
 
-  .pane-row > * {
+  atom-pane-axis.horizontal > * {
     border-right: 1px solid @pane-item-border-color;
     &:last-child { border-right: none; }
   }
 
-  .pane-column > * {
+  atom-pane-axis.vertical > * {
     border-bottom: 1px solid @pane-item-border-color;
     &:last-child { border-bottom: none; }
   }

--- a/stylesheets/zen.less
+++ b/stylesheets/zen.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 
 .zen {
-  .panes .pane {
+  atom-pane-container atom-pane {
     background-color: @app-background-color;
   }
 }


### PR DESCRIPTION
Atom API 1.0 deprecated a bunch of selectors. This PR removes the use of those selectors.