### PR TITLE
Fix #6, add scrollbar corner style

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -19,16 +19,19 @@
 }
 
 .tree-view-resizer, atom-text-editor {
-  ::-webkit-scrollbar {
+  /deep/ ::-webkit-scrollbar {
     width: 1em;
     height: 1em;
   }
-
-  ::-webkit-scrollbar-track {
+  /deep/ ::-webkit-scrollbar-track {
     background-color: #2B303B;
   }
 
-  ::-webkit-scrollbar-thumb {
+  /deep/ ::-webkit-scrollbar-thumb {
     background-color: #232830;
+  }
+
+  /deep/ ::-webkit-scrollbar-corner {
+    background-color: #1C1F25; 
   }
 }


### PR DESCRIPTION
Fix for #6, where scrollbars in the editor would not be styled. Also adds a style for the scrollbar corner in case both horizontal and vertical scrollbars are displayed simultaneously.
![screen shot 2015-05-12 at 19 48 48]
(https://cloud.githubusercontent.com/assets/6472410/7594329/20b211ac-f8e0-11e4-9e75-41ebe82f9eaf.png)
