### PR TITLE
Replace deprecated selector with shadow

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -23,7 +23,7 @@ atom-text-editor[mini].is-focused {
   to { background-color: null; }
 }
 
-atom-text-editor::shadow .highlighted.selection .region {
+atom-text-editor.editor .highlighted.selection .region {
   -webkit-animation-name: highlight;
   -webkit-animation-duration: 1s;
   -webkit-animation-iteration-count: 1;


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. See #29 