### PR TITLE
Fix scrollbar UI issue on .tree-view

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -10,7 +10,7 @@
 
 .scrollbars-visible-always {
   ::-webkit-scrollbar,
-  /deep/ ::-webkit-scrollbar, {
+  /deep/ ::-webkit-scrollbar {
     width: 1em;
     height: 1em;
   }

--- a/styles/atom.less
+++ b/styles/atom.less
@@ -7,3 +7,26 @@
 .atom-workspace {
   background-color: @app-background-color;
 }
+
+.scrollbars-visible-always {
+  ::-webkit-scrollbar,
+  /deep/ ::-webkit-scrollbar, {
+    width: 1em;
+    height: 1em;
+  }
+
+  ::-webkit-scrollbar-corner,
+  /deep/ ::-webkit-scrollbar-corner {
+    background-color: #1C1F25;
+  }
+
+  ::-webkit-scrollbar-track,
+  /deep/ ::-webkit-scrollbar-track {
+    background-color: #2B303B;
+  }
+
+  ::-webkit-scrollbar-thumb,
+  /deep/ ::-webkit-scrollbar-thumb {
+    background-color: #232830;
+  }
+}

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -17,21 +17,3 @@
     }
   }
 }
-
-.tree-view-resizer, atom-text-editor {
-  /deep/ ::-webkit-scrollbar {
-    width: 1em;
-    height: 1em;
-  }
-  /deep/ ::-webkit-scrollbar-track {
-    background-color: #2B303B;
-  }
-
-  /deep/ ::-webkit-scrollbar-thumb {
-    background-color: #232830;
-  }
-
-  /deep/ ::-webkit-scrollbar-corner {
-    background-color: #1C1F25; 
-  }
-}


### PR DESCRIPTION
When I was using 'spacegrey-dark-ui' theme and expand folders until scrollbar appear on .tree-view, then default Webkit scrollbar appears instead styled scrollbar. This pull-request is resolving this issue and also, styled scrollbar will come up on .tree-view.

Since @cannikin doesn't use Atom editor anymore, you can resolve by following this code on your stylesheet,

```
.scrollbars-visible-always {
  ::-webkit-scrollbar,
  /deep/ ::-webkit-scrollbar {
    width: 1em;
    height: 1em;
  }

  ::-webkit-scrollbar-corner,
  /deep/ ::-webkit-scrollbar-corner {
    background-color: #1C1F25;
  }

  ::-webkit-scrollbar-track,
  /deep/ ::-webkit-scrollbar-track {
    background-color: #2B303B;
  }

  ::-webkit-scrollbar-thumb,
  /deep/ ::-webkit-scrollbar-thumb {
    background-color: #232830;
  }
}
```

I hope this commits is fixing #27 issue. 